### PR TITLE
New/readme/directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ At the time of writing and as an example, this is the directory structure.
 
 ```
 contracts ------ examples ------ access
+            |
 	        |--- advanced ------ access
+            |
 	        |--- test     ------ issuance
+            |               |--- token
+            |
 	        |--- drafts   ------ access
 	        |               |--- issuance
 	        |               |--- strings

--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ The `test` directory replicates the structure of the `contracts` directory.
 At the time of writing and as an example, this is the directory structure.
 
 ```
-contracts ------ examples ------ access
-            |
-	        |--- advanced ------ access
-            |
-	        |--- test     ------ issuance
-            |               |--- token
-            |
-	        |--- drafts   ------ access
-	        |               |--- issuance
-	        |               |--- strings
-	        |               \--- token
-	        |
-	        |--- access
-	        |--- lists
-	        \--- state
+contracts ──┬─── examples ────── access
+            │
+	        ├─── advanced ────── access
+            │
+	        ├─── test     ──┬─── issuance
+            │               └─── token
+            │
+	        ├─── drafts   ──┬─── access
+	        │               ├─── issuance
+	        │               ├─── strings
+	        │               └─── token
+	        │
+	        ├─── access
+	        ├─── lists
+	        └─── state
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -27,6 +27,38 @@ Use the package manager [yarn](https://yarnpkg.com) to install dependencies.
 $ yarn
 ```
 
+## Directories
+
+Contracts go in `contracts`, test files go in `test`.
+
+Inside the contracts folder the files are organized by topic and by type.
+
+Current topics are access, lists, state, strings and token. This list might not be exhaustive.
+
+At the root of `contracts` are directories for each one of the topics, containing the simplest implementations that are in a mature state.
+For contracts that are used as example implementations there is a `contracts/examples` directory with the appropriate topic folders inside.
+For contracts that are more complex and complete implementations of the base topics there is a `contracts/advanced` directory with the appropriate topic folders inside.
+For contracts that are under development there is a `contracts/drafts` directory with the appropriate topic folders inside.
+For contracts that are used for testing of libraries or internal methods there is a `contracts/tests` directory with the appropriate topic folders inside.
+
+The `test` directory replicates the structure of the `contracts` directory.
+
+At the time of writing and as an example, this is the directory structure.
+
+```
+contracts ------ examples ------ access
+	        |--- advanced ------ access
+	        |--- test     ------ issuance
+	        |--- drafts   ------ access
+	        |               |--- issuance
+	        |               |--- strings
+	        |               \--- token
+	        |
+	        |--- access
+	        |--- lists
+	        \--- state
+```
+
 ## Usage
 
 ```solidity


### PR DESCRIPTION
I thought of a directory structure to keep our efforts organized.

One key concept which I think is important, and that will differentiate us from OpenZeppelin, is the `advanced` directory.

The idea is that the first thing that users will see will be very simple implementations of patterns, which they can inherit from or reimplement as they see fit.

Adding flexibility and functionality to contracts is nice, but it detracts from how easy they are to understand. We do complex contracts as well but we put them in `advanced` so that only the users that are ready for those things dive into them.

An easy example is `Whitelist.sol` and making it ERC165 compliant. It's cool, it's necessary, but doing it from scratch makes things complicated, so I leave in `contracts/access` the base implementation which is easy to understand, and in `contracts/advanced/access` the one that implements ERC165.

That organization will also make our `Issuance.sol` different from OpenZeppelin's `Crowdfund.sol`. Our implementation will be easier to understand, even if theirs is more useful to inherit from. If someone decides to implement their own crowdfund contract from scratch, they will find it easier if they start from ours than theirs.

Thoughts?