### PR TITLE
Abstracted ERC20Mintable to an interface.

### DIFF
--- a/contracts/drafts/issuance/IERC20Mintable.sol
+++ b/contracts/drafts/issuance/IERC20Mintable.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.10;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
+ * the optional functions; to access them see {ERC20Detailed}.
+ */
+interface IERC20Mintable {
+    /**
+     * @dev See {ERC20-_mint}.
+     *
+     * Requirements:
+     *
+     * - the caller must have the {MinterRole}.
+     */
+    function mint(address account, uint256 amount)
+        external
+        returns(bool);
+}

--- a/contracts/drafts/issuance/Issuance.sol
+++ b/contracts/drafts/issuance/Issuance.sol
@@ -4,6 +4,7 @@ import "@openzeppelin/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "./IERC20Mintable.sol";
 import "./../../state/StateMachine.sol";
 
 
@@ -27,7 +28,7 @@ contract Issuance is Ownable, StateMachine, ReentrancyGuard {
     event InvestmentCancelled(address investor, uint256 amount);
 
     IERC20 public currencyToken;
-    ERC20Mintable public issuanceToken;
+    IERC20Mintable public issuanceToken;
 
     address[] public investors;
     mapping(address => uint256) public investments;
@@ -46,7 +47,7 @@ contract Issuance is Ownable, StateMachine, ReentrancyGuard {
         address _issuanceToken,
         address _currencyToken
     ) public Ownable() StateMachine() {
-        issuanceToken = ERC20Mintable(_issuanceToken);
+        issuanceToken = IERC20Mintable(_issuanceToken);
         currencyToken = IERC20(_currencyToken);
         _createState("OPEN");
         _createState("LIVE");


### PR DESCRIPTION
I don't like casting addresses to contracts, better to use an interface.

The weird thing is that I don't need to modify the implementation for ERC20Mintable.sol. It is defined without any reference to IERC20Mintable.sol:

`contract ERC20Mintable is ERC20, MinterRole {`

And yet the cast works:

`issuanceToken = IERC20Mintable(_issuanceToken);`

So I assume inheriting from the interface is just useful to let you know that you are not implementing an interface at compiling time:

`contract ERC20 is Context, IERC20 {` would work the same as `contract ERC20 is Context {` at runtime.
