### PR TITLE
Moved all mock contracts to `contracts/test`. - Fixes #198

### DIFF
--- a/contracts/test/access/RenounceableMock.sol
+++ b/contracts/test/access/RenounceableMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.10;
 import "./RolesMock.sol";
-import "../Renounceable.sol";
+import "./../../access/Renounceable.sol";
 
 
 contract RenounceableMock is RolesMock, Renounceable {

--- a/contracts/test/access/RolesMock.sol
+++ b/contracts/test/access/RolesMock.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.5.10;
-import "../Roles.sol";
+import "./../../access/Roles.sol";
 
 
 contract RolesMock is Roles {

--- a/contracts/test/access/TransferrableMock.sol
+++ b/contracts/test/access/TransferrableMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.10;
 import "./RolesMock.sol";
-import "../Transferrable.sol";
+import "./../../access/Transferrable.sol";
 
 
 contract TransferrableMock is RolesMock, Transferrable {

--- a/contracts/test/lists/TestLinkedList.sol
+++ b/contracts/test/lists/TestLinkedList.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.5.10;
-import "./../LinkedList.sol";
+import "./../../lists/LinkedList.sol";
 
 
 /**

--- a/test/lists/LinkedList.test.ts
+++ b/test/lists/LinkedList.test.ts
@@ -2,12 +2,9 @@ import { should } from 'chai';
 import { LinkedListInstance } from '../../types/truffle-contracts';
 import { TestLinkedListInstance } from '../../types/truffle-contracts';
 
-const LinkedList = artifacts.require('./lists/LinkedList.sol')  as Truffle.Contract<LinkedListInstance>;
-const TestLinkedList = artifacts.require(
-    './lists/mocks/TestLinkedList.sol',
-)  as Truffle.Contract<TestLinkedListInstance>;
+const LinkedList = artifacts.require('LinkedList')  as Truffle.Contract<LinkedListInstance>;
+const TestLinkedList = artifacts.require('TestLinkedList') as Truffle.Contract<TestLinkedListInstance>;
 should();
-
 
 const emptyData = '0x0000000000000000000000000000000000000000';
 const headData = '0x0000000000000000000000000000000000000001';


### PR DESCRIPTION
Some mock contracts were being distributed with the package.