### PR TITLE
WIP: Fix transfer dividendability

### DIFF
--- a/contracts/token/ERC20DividendableEth.sol
+++ b/contracts/token/ERC20DividendableEth.sol
@@ -44,9 +44,9 @@ contract ERC20DividendableEth is ERC20MintableDetailed {
         address recipient,
         uint256 amount
     ) public returns (bool) {
-        int256 weight = amount.divd(this.balanceOf(recipient));
-        int256 differentialDPT = lastDPT[msg.sender].subd(lastDPT[recipient]);
-        int256 weightedDifferential = differentialDPT.muld(weight);
+        uint256 weight = amount.divd(this.balanceOf(recipient));
+        uint256 differentialDPT = lastDPT[msg.sender].subd(lastDPT[recipient]);
+        uint256 weightedDifferential = differentialDPT.muld(weight);
         adjustmentDPT[recipient] = adjustmentDPT[recipient]
             .addd(weightedDifferential);
         return super.transfer(recipient, amount);
@@ -69,10 +69,10 @@ contract ERC20DividendableEth is ERC20MintableDetailed {
         address recipient,
         uint256 amount
     ) public returns (bool) {
-        int256 weight = amount.divd(this.balanceOf(recipient));
+        uint256 weight = amount.divd(this.balanceOf(recipient));
         uint256 differentialDPT = lastDPT[sender]
-            .subd(lastDividendsPerToken[recipient]);
-        int256 weightedDifferential = differentialDPT.muld(weight);
+            .subd(lastDPT[recipient]);
+        uint256 weightedDifferential = differentialDPT.muld(weight);
         adjustmentDPT[recipient] = adjustmentDPT[recipient]
             .addd(weightedDifferential);
         return super.transferFrom(sender, recipient, amount);
@@ -105,7 +105,7 @@ contract ERC20DividendableEth is ERC20MintableDetailed {
     {
         uint256 owing = dividendsOwing(account);
         require(owing > 0, "Account need not be updated now.");
-        DPTadjustment[account] = 0;
+        adjustmentDPT[account] = 0;
         lastDPT[account] = dividendsPerToken;
         account.transfer(owing);
         return owing;
@@ -117,7 +117,7 @@ contract ERC20DividendableEth is ERC20MintableDetailed {
      */
     function dividendsOwing(address account) internal view returns(uint256) {
         uint256 owedDPT = dividendsPerToken
-            .subd(lastDPT[account]).addd(DPTadjustment[account]);
+            .subd(lastDPT[account]).addd(adjustmentDPT[account]);
         return this.balanceOf(account).muld(owedDPT);
     }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@hq20/fixidity": "^0.1.0-alpha.1"
     },
     "devDependencies": {
-        "@hq20/fixidity": "0.1.0-alpha.1",
+        "@hq20/fixidity": "0.1.0-alpha.2",
         "@openzeppelin/contracts": "2.5.0",
         "@openzeppelin/test-helpers": "0.5.4",
         "@truffle/hdwallet-provider": "1.0.31",

--- a/test/token/ERC20DividendableEth.test.ts
+++ b/test/token/ERC20DividendableEth.test.ts
@@ -1,7 +1,7 @@
 import { should } from 'chai';
 
 // tslint:disable-next-line:no-var-requires
-const { balance, BN, constants, ether, expectEvent, expectRevert, send } = require('@openzeppelin/test-helpers');
+const { BN, ether, expectRevert } = require('@openzeppelin/test-helpers');
 
 import { TestERC20DividendableEthInstance } from '../../types/truffle-contracts';
 
@@ -94,7 +94,8 @@ contract('ERC20DividendableEth', (accounts) => {
         await erc20dividendableEth.releaseDividends({ from: user1, value: profits.toString()});
         await erc20dividendableEth.claimDividends({ from: account2 });
         await erc20dividendableEth.transfer(account2, transfer, { from: account1 });
-        BN(await erc20dividendableEth.claimDividends.call({ from: account2 })).should.be.bignumber.gt(ether('6.59')).and.lt(ether('6.61'));
+        BN(await erc20dividendableEth.claimDividends.call({ from: account2 }))
+            .should.be.bignumber.gt(ether('6.59')).and.lt(ether('6.61'));
     });
 
     /**

--- a/test/token/ERC20DividendableEth.test.ts
+++ b/test/token/ERC20DividendableEth.test.ts
@@ -111,6 +111,7 @@ contract('ERC20DividendableEth', (accounts) => {
         await erc20dividendableEth.releaseDividends({ from: user1, value: releasedDividends.toString()});
         await erc20dividendableEth.claimDividends({ from: account1 });
         await erc20dividendableEth.transfer(account2, transferTokens, { from: account1 });
-        BN(await erc20dividendableEth.claimDividends.call({ from: account2 })).should.be.bignumber.equal(claimedDividends2);
+        BN(await erc20dividendableEth.claimDividends.call({ from: account2 }))
+            .should.be.bignumber.equal(claimedDividends2);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,12 +115,12 @@
     "@ethersproject/constants" ">=5.0.0-beta.128"
     "@ethersproject/logger" ">=5.0.0-beta.129"
 
-"@hq20/fixidity@0.1.0-alpha.1":
-  version "0.1.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@hq20/fixidity/-/fixidity-0.1.0-alpha.1.tgz#c33878c390815e48d80cc2bee6e9bd90943a912f"
-  integrity sha512-MPrDHLWny6qO5hbfjT0un7gNCt9HnJRnII4/NFKKIiFVaao2OImtfvLuJhtpv1vX7oDH73Z4eSXW43dmWuIXsQ==
+"@hq20/fixidity@0.1.0-alpha.2":
+  version "0.1.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@hq20/fixidity/-/fixidity-0.1.0-alpha.2.tgz#a3e0ddcc71aac68578757d89a167470766b621e0"
+  integrity sha512-slSKTCgtymLY2mo7aB4P7qq65SR46lI4zcyeg30f2TLuz01oa4Aa+EX/PRewHV5ZFKnhDCnMfy0s6SeIgQMGbA==
   dependencies:
-    "@truffle/hdwallet-provider" "1.0.29"
+    "@truffle/hdwallet-provider" "1.0.31"
     bignumber.js "9.0.0"
 
 "@hq20/solidity-parser-antlr@0.4.12-alpha.0":
@@ -232,21 +232,6 @@
   resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.8.tgz#dc94ca36393403449d4b7461bf9452c241e53ec1"
   integrity sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ==
 
-"@truffle/hdwallet-provider@1.0.29":
-  version "1.0.29"
-  resolved "https://registry.yarnpkg.com/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.29.tgz#711bf29049750fe629edb8c304ee5c6b04919a92"
-  integrity sha512-GN/eUINLXHnsUPx3PJvGd6WKnAOXP0MYK/aVhlE7PekYapHjimg0EVo8HrnDSQw6LxYRFiXP3lhyEK6J9witbg==
-  dependencies:
-    any-promise "^1.3.0"
-    bindings "^1.5.0"
-    bip39 "^2.4.2"
-    ethereum-protocol "^1.0.1"
-    ethereumjs-tx "^1.0.0"
-    ethereumjs-util "^6.1.0"
-    ethereumjs-wallet "^0.6.3"
-    web3 "1.2.1"
-    web3-provider-engine "https://github.com/trufflesuite/provider-engine#web3-one"
-
 "@truffle/hdwallet-provider@1.0.31":
   version "1.0.31"
   resolved "https://registry.yarnpkg.com/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.31.tgz#fafb4caa7a1bc234dd2af3543fa98eb491f257e1"
@@ -260,7 +245,7 @@
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "^0.6.3"
     web3 "1.2.1"
-    web3-provider-engine "git+https://github.com/trufflesuite/provider-engine.git#web3-one"
+    web3-provider-engine "https://github.com/trufflesuite/provider-engine#web3-one"
 
 "@truffle/interface-adapter@^0.3.0":
   version "0.3.3"
@@ -7885,33 +7870,7 @@ web3-net@1.2.6:
 
 "web3-provider-engine@git+https://github.com/trufflesuite/provider-engine.git#web3-one":
   version "14.0.6"
-  uid "3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
   resolved "git+https://github.com/trufflesuite/provider-engine.git#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
-  dependencies:
-    async "^2.5.0"
-    backoff "^2.5.0"
-    clone "^2.0.0"
-    cross-fetch "^2.1.0"
-    eth-block-tracker "^3.0.0"
-    eth-json-rpc-infura "^3.1.0"
-    eth-sig-util "^1.4.2"
-    ethereumjs-block "^1.2.2"
-    ethereumjs-tx "^1.2.0"
-    ethereumjs-util "^5.1.5"
-    ethereumjs-vm "^2.3.4"
-    json-rpc-error "^2.0.0"
-    json-stable-stringify "^1.0.1"
-    promise-to-callback "^1.0.0"
-    readable-stream "^2.2.9"
-    request "^2.85.0"
-    semaphore "^1.0.3"
-    ws "^5.1.1"
-    xhr "^2.2.0"
-    xtend "^4.0.1"
-
-"web3-provider-engine@https://github.com/trufflesuite/provider-engine#web3-one":
-  version "14.0.6"
-  resolved "https://github.com/trufflesuite/provider-engine#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"


### PR DESCRIPTION
Fixes #215.

Alright, I've been banging my head with this and still can't figure it out.
The first test fails by an order of just 10.
The second reverts.
Also, had to add an `.abs()` somewhere in the differential because there was a subtraction overflow, not sure if the formula thus preserves its validity.
Begging for help...

But still, I am not convinced we need this. Dividends are disbursed to holders based on the balances at the time of dividend incoming, not at the time of claiming, aren't they (in which case the transfer bug is a bug no more)? If I have 50% of a company, and I disburse dividends annually, say I make in February 100$, and in December I quit from the board. At the end of the year, shouldn't I get those 50$ that is rightfully mine? If we solve this bug, the answer would be a staggering no.