### PR TITLE
Renamed TwoTiered and applied it to tokens.

### DIFF
--- a/contracts/access/Administered.sol
+++ b/contracts/access/Administered.sol
@@ -4,11 +4,11 @@ import "./Renounceable.sol";
 
 
 /**
- * @title TwoTiered
+ * @title Administered
  * @author Alberto Cuesta Canada
- * @notice Implements a two-role Roles
+ * @notice Implements Admin and User roles.
  */
-contract TwoTiered is Roles, Renounceable {
+contract Administered is Roles, Renounceable {
     bytes32 public constant ADMIN_ROLE_ID = "ADMIN";
     bytes32 public constant USER_ROLE_ID = "USER";
 

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -28,15 +28,15 @@ In `Community.sol`:
 * function `leaveCommunity()`: Removes the caller as a member.
 
 
-# TwoTiered
+# Administered
 
 This is an Ethereum project extending `Roles.sol` that implements a simple two-tier access control system.
 
 ## Usage
 
-In `TwoTiered.sol`:
+In `Administered.sol`:
 
-* constructor `(address root)`: The address deploying TwoTiered.sol will be the first admin. Only admins can execute transactional methods.
+* constructor `(address root)`: The address deploying Administered.sol will be the first admin. Only admins can execute transactional methods.
 
 * function `isUser(address account)`: Returns `true` if `account` is an user, and `false` otherwise.
 * function `isAdmin(address account)`: Returns `true` if `account` is an admin, and `false` otherwise.

--- a/contracts/examples/access/ERC20MintableHQ20.sol
+++ b/contracts/examples/access/ERC20MintableHQ20.sol
@@ -1,19 +1,19 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../../access/TwoTiered.sol";
+import "../../access/Administered.sol";
 
 
 /**
- * @dev Extension of {ERC20} using a {TwoTiered} organization to give minting rights.
+ * @dev Extension of {ERC20} using a {Administered} organization to give minting rights.
  * Users are allowed to mint (create) new tokens.
  * Admins are allowed to add or remove accounts to the Users group.
  * Admins are allowed to add accounts to the Admins group.
  * Admins are allowed to renounce their membership to the Admins group.
  * At construction, the deployer of the contract is the only Admin.
  */
-contract ERC20MintableHQ20 is ERC20, TwoTiered {
-    constructor (address admin) TwoTiered(admin) public {}
+contract ERC20MintableHQ20 is ERC20, Administered {
+    constructor (address admin) Administered(admin) public {}
 
     /// @dev Only Users can mint new tokens
     function mint(address account, uint256 amount)

--- a/contracts/examples/dao/VentureEth.sol
+++ b/contracts/examples/dao/VentureEth.sol
@@ -32,7 +32,7 @@ IssuanceEth {
     ERC20DividendableEth(name, symbol, decimals)
     IssuanceEth(address(this))
     {
-        addMember(address(this));
+        addAdmin(address(this));
     }
 
 }

--- a/contracts/examples/energy/EnergyMarket.sol
+++ b/contracts/examples/energy/EnergyMarket.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 // import "@hq20/contracts/contracts/access/Whitelist.sol";
-import "../../access/TwoTiered.sol";
+import "../../access/Administered.sol";
 
 
 /**
@@ -13,7 +13,7 @@ import "../../access/TwoTiered.sol";
  * to the producers. Whitelist is used to keep a list of compliant smart
  * meters that communicate the production and consumption of energy.
  */
-contract EnergyMarket is ERC20, TwoTiered {
+contract EnergyMarket is ERC20, Administered {
 
     event EnergyProduced(address producer, uint256 time);
     event EnergyConsumed(address consumer, uint256 time);
@@ -34,7 +34,7 @@ contract EnergyMarket is ERC20, TwoTiered {
     constructor (uint256 _initialSupply, uint128 _basePrice)
         public
         ERC20()
-        TwoTiered(msg.sender)
+        Administered(msg.sender)
     {
         _mint(address(this), _initialSupply);
         basePrice = _basePrice;

--- a/contracts/token/ERC20Mintable.sol
+++ b/contracts/token/ERC20Mintable.sol
@@ -1,22 +1,22 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../access/Community.sol";
+import "../access/Administered.sol";
 
 
 /**
  * @dev Extension of {ERC20} that gives the owner permission to mint (create) new tokens as he sees fit.
  */
-contract ERC20Mintable is ERC20, Community {
+contract ERC20Mintable is ERC20, Administered {
     constructor ()
         public
-        Community(msg.sender)
+        Administered(msg.sender)
     { }
 
     function mint(address account, uint256 amount)
         public
         virtual
-        onlyMember
+        onlyAdmin
         returns (bool)
     {
         _mint(account, amount);

--- a/contracts/token/ERC721Mintable.sol
+++ b/contracts/token/ERC721Mintable.sol
@@ -1,22 +1,22 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "../access/Community.sol";
+import "../access/Administered.sol";
 
 
 /**
  * @dev Extension of {ERC721} that gives the owner permission to mint (create) new tokens as he sees fit.
  */
-contract ERC721Mintable is ERC721, Community {
+contract ERC721Mintable is ERC721, Administered {
     constructor ()
         public
-        Community(msg.sender)
+        Administered(msg.sender)
     { }
 
     function mint(address account, uint256 amount)
         public
         virtual
-        onlyMember
+        onlyAdmin
         returns (bool)
     {
         _mint(account, amount);

--- a/contracts/voting/OneManOneVote.sol
+++ b/contracts/voting/OneManOneVote.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "../math/DecimalMath.sol";
-import "../access/TwoTiered.sol";
+import "../access/Administered.sol";
 
 
 /**
@@ -21,7 +21,7 @@ import "../access/TwoTiered.sol";
  * 6. Electoral officers enact the proposal. There is no limit to how many times the proposal can be enacted from one successful vote.
  * As-is, this contract can be easily abused by dishonest electoral officers. A time-bound voting process with a limit block for voter enrollment and a limit block for vote casting would be more robust.
  */
-contract OneManOneVote is TwoTiered {
+contract OneManOneVote is Administered {
     using DecimalMath for uint256;
     using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -49,7 +49,7 @@ contract OneManOneVote is TwoTiered {
         address _targetContract,
         bytes memory _proposalData,
         uint256 _threshold
-    ) public TwoTiered(_root) {
+    ) public Administered(_root) {
         threshold = _threshold;
         targetContract = _targetContract;
         proposalData = _proposalData;

--- a/test/access/TwoTiered.test.ts
+++ b/test/access/TwoTiered.test.ts
@@ -1,101 +1,101 @@
 import { should } from 'chai';
-import { TwoTieredInstance } from '../../types/truffle-contracts';
+import { AdministeredInstance } from '../../types/truffle-contracts';
 // tslint:disable:no-var-requires
 const { expectRevert } = require('@openzeppelin/test-helpers');
 
-const TwoTiered = artifacts.require('TwoTiered') as Truffle.Contract<TwoTieredInstance>;
+const Administered = artifacts.require('Administered') as Truffle.Contract<AdministeredInstance>;
 should();
 
-/** @test {TwoTiered} contract */
-contract('TwoTiered', (accounts) => {
-    let twoTiered: TwoTieredInstance;
+/** @test {Administered} contract */
+contract('Administered', (accounts) => {
+    let administered: AdministeredInstance;
     const root = accounts[0];
     const user1 = accounts[1];
 
     beforeEach(async () => {
-        twoTiered = await TwoTiered.new(root);
+        administered = await Administered.new(root);
     });
 
     /**
-     * @test {TwoTiered#isAdmin}
+     * @test {Administered#isAdmin}
      */
     it('isAdmin returns true for admins', async () => {
-        assert.isTrue(await twoTiered.isAdmin(root));
-        assert.isFalse(await twoTiered.isAdmin(user1));
+        assert.isTrue(await administered.isAdmin(root));
+        assert.isFalse(await administered.isAdmin(user1));
     });
 
     /**
-     * @test {TwoTiered#isUser}
+     * @test {Administered#isUser}
      */
     it('isUser returns false for non existing users', async () => {
-        assert.isFalse(await twoTiered.isUser(user1));
+        assert.isFalse(await administered.isUser(user1));
     });
 
     /**
-     * @test {TwoTiered#addUser}
+     * @test {Administered#addUser}
      */
     it('addUser throws if not called by an admin account.', async () => {
         await expectRevert(
-            twoTiered.addUser(user1, { from: user1 }),
+            administered.addUser(user1, { from: user1 }),
             'Restricted to admins.',
         );
     });
 
     /**
-     * @test {TwoTiered#addAdmin}
+     * @test {Administered#addAdmin}
      */
     it('addAdmin throws if not called by an admin account.', async () => {
         await expectRevert(
-            twoTiered.addAdmin(user1, { from: user1 }),
+            administered.addAdmin(user1, { from: user1 }),
             'Restricted to admins.',
         );
     });
 
     /**
-     * @test {TwoTiered#renounceAdmin}
+     * @test {Administered#renounceAdmin}
      */
     it('renounceAdmin removes an user from the admin role.', async () => {
-        await twoTiered.renounceAdmin({ from: root });
-        assert.isFalse(await twoTiered.isAdmin(root));
+        await administered.renounceAdmin({ from: root });
+        assert.isFalse(await administered.isAdmin(root));
     });
 
     /**
-     * @test {TwoTiered#removeUser}
+     * @test {Administered#removeUser}
      */
     it('removeUser throws if not called by an admin account.', async () => {
         await expectRevert(
-            twoTiered.removeUser(user1, { from: user1 }),
+            administered.removeUser(user1, { from: user1 }),
             'Restricted to admins.',
         );
     });
 
     /**
-     * @test {TwoTiered#addUser} and {TwoTiered#isUser}
+     * @test {Administered#addUser} and {Administered#isUser}
      */
     it('addUser adds an account as an user.', async () => {
-        await twoTiered.addUser(user1, { from: root });
-        assert.isTrue(await twoTiered.isUser(user1));
+        await administered.addUser(user1, { from: root });
+        assert.isTrue(await administered.isUser(user1));
     });
 
     /**
-     * @test {TwoTiered#addUser} and {TwoTiered#isUser}
+     * @test {Administered#addUser} and {Administered#isUser}
      */
     it('addAdmin adds an account as an admin.', async () => {
-        await twoTiered.addAdmin(user1, { from: root });
-        assert.isTrue(await twoTiered.isAdmin(user1));
+        await administered.addAdmin(user1, { from: root });
+        assert.isTrue(await administered.isAdmin(user1));
     });
 
     describe('with existing users', () => {
         beforeEach(async () => {
-            await twoTiered.addUser(user1, { from: root });
+            await administered.addUser(user1, { from: root });
         });
 
         /**
-         * @test {TwoTiered#removeUser}
+         * @test {Administered#removeUser}
          */
         it('removeUser removes an user.', async () => {
-            await twoTiered.removeUser(user1, { from: root });
-            assert.isFalse(await twoTiered.isUser(user1));
+            await administered.removeUser(user1, { from: root });
+            assert.isFalse(await administered.isUser(user1));
         });
     });
 });

--- a/test/issuance/Issuance.test.ts
+++ b/test/issuance/Issuance.test.ts
@@ -37,7 +37,7 @@ contract('Issuance', (accounts) => {
             issuanceToken.address,
             currencyToken.address,
         );
-        await issuanceToken.addMember(issuance.address);
+        await issuanceToken.addAdmin(issuance.address);
         await currencyToken.mint(investor1, balance1);
         await currencyToken.mint(investor2, balance2);
         await currencyToken.approve(issuance.address, investment1, { from: investor1 });

--- a/test/issuance/IssuanceEth.test.ts
+++ b/test/issuance/IssuanceEth.test.ts
@@ -30,7 +30,7 @@ contract('IssuanceEth', (accounts) => {
     beforeEach(async () => {
         issuanceToken = await ERC20MintableDetailed.new('IssuanceToken', 'ISST', 17);
         issuanceEth = await IssuanceEth.new(issuanceToken.address);
-        await issuanceToken.addMember(issuanceEth.address);
+        await issuanceToken.addAdmin(issuanceEth.address);
     });
 
     /**

--- a/test/voting/OneManOneVote.test.ts
+++ b/test/voting/OneManOneVote.test.ts
@@ -42,7 +42,7 @@ contract('OneManOneVote', (accounts) => {
             }, [owner, '1']),
             threshold,
         );
-        await votedToken.addMember(voting.address);
+        await votedToken.addAdmin(voting.address);
         await voting.addUser(voter1, { from: officer });
         await voting.addUser(voter2, { from: officer });
     });

--- a/test/voting/OneTokenOneVote.test.ts
+++ b/test/voting/OneTokenOneVote.test.ts
@@ -51,7 +51,7 @@ contract('OneTokenOneVote', (accounts) => {
         await votingToken.mint(voter2, balance2);
         await votingToken.approve(voting.address, votes1, { from: voter1 });
         await votingToken.approve(voting.address, votes2, { from: voter2 });
-        await votedToken.addMember(voting.address);
+        await votedToken.addAdmin(voting.address);
     });
 
     /**


### PR DESCRIPTION
Renamed TwoTiered for Administered. It still does the same thing of implementing an user and an admin roles.

Then I refactored ERC20Mintable and ERC721Mintable to use it. In tests it makes more sense to say that admins are the only ones that can mint.

Previously the tokens used Community.sol, which has a single role and was not too obvious in tests how it worked.

It is clearer this way.