### PR TITLE
AuthorizedAccess.sol

### DIFF
--- a/contracts/access/AuthorizedAccess.sol
+++ b/contracts/access/AuthorizedAccess.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.6.0;
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+
+/// @dev AuthorizedAccess allows to define simple access control for multiple authorized
+/// Think of it as a simple two tiered access control contract. It has an owner which can
+/// execute functions with the `onlyOwner` modifier, and the owner can give access to other
+/// addresses which then can execute functions with the `onlyAuthorized` modifier.
+contract AuthorizedAccess is Ownable {
+    event GrantedAccess(address user);
+    event RevokedAccess(address user);
+
+    mapping(address => bool) private authorized;
+
+    constructor () public Ownable() {}
+
+    /// @dev Restrict usage to authorized users
+    modifier onlyAuthorized(string memory err) {
+        require(authorized[msg.sender], err);
+        _;
+    }
+
+    /// @dev Add user to the authorized users list
+    function grantAccess(address user) public onlyOwner {
+        authorized[user] = true;
+        emit GrantedAccess(user);
+    }
+
+    /// @dev Remove user to the authorized users list
+    function revokeAccess(address user) public onlyOwner {
+        authorized[user] = false;
+        emit RevokedAccess(user);
+    }
+}

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -48,3 +48,31 @@ In `Hierarchy.sol`:
 
 * function `isMember(address account, bytes32 roleId)`: Returns `true` if `account` belongs to the admin role of `roleId`.
 * function `addRole(bytes32 roleId, bytes32 adminRoleId)`: Adds `roleId` with `adminRoleId` as the admin role.
+
+# Democracy
+
+This is version of `Administered.sol` where roles are granted or revoked only through a vote, initiated by calling the `propose()` function. The call to `propose()` emits an event with the address of the voting, which can be used to `vote`, `validate` and `enact` the proposal.
+
+## Usage
+```
+const proposalData = web3.eth.abi.encodeFunctionCall({
+    name: 'addLeader',
+    type: 'function',
+    inputs: [{
+        type: 'address',
+        name: 'account',
+    }]
+}, [root]);
+const votingAddress = (
+    await democracy.propose(proposalData, { from: root })
+).logs[0].args.proposal;
+voting = await Voting.at(votingAddress);
+await token.approve(voting.address, 1, { from: root });
+await voting.vote(1, { from: root });
+await voting.validate();
+await voting.enact();
+```
+
+# AuthorizedAccess
+
+AuthorizedAccess allows to define simple access control for multiple authorized users. Think of it as a simple two tiered access control contract. It has an owner which can execute functions with the `onlyOwner` modifier, and the owner can give access to other addresses which then can execute functions with the `onlyAuthorized` modifier.

--- a/contracts/test/access/TestAuthorizedAccess.sol
+++ b/contracts/test/access/TestAuthorizedAccess.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.6.0;
+import "./../../access/AuthorizedAccess.sol";
+
+
+contract TestAuthorizedAccess is AuthorizedAccess {
+    constructor () public AuthorizedAccess() {}
+    function testOnlyAuthorized(string memory msg)
+        public view onlyAuthorized(msg) returns(bool)
+    {
+        return true;
+    }
+}

--- a/test/access/AuthorizedAccess.ts
+++ b/test/access/AuthorizedAccess.ts
@@ -1,0 +1,55 @@
+import { should } from 'chai';
+import { TestAuthorizedAccessInstance } from '../../types/truffle-contracts';
+
+const TestAuthorizedAccess = artifacts.require(
+    'TestAuthorizedAccess'
+) as Truffle.Contract<TestAuthorizedAccessInstance>;
+
+should();
+
+// tslint:disable:no-var-requires
+const { expectRevert } = require('@openzeppelin/test-helpers');
+
+contract('AuthorizedAccess', async (accounts) =>    {
+    let testAccess: TestAuthorizedAccessInstance;
+    const [ owner, user ] = accounts;
+
+    beforeEach(async() => {
+        testAccess = await TestAuthorizedAccess.new({ from: owner });
+    });
+
+    it('unauthorized access is rejected', async() => {
+        const err = 'Error';
+        await expectRevert(
+            testAccess.testOnlyAuthorized(err, { from: user }),
+            err,
+        );
+    });
+
+    it('addresses can be granted access', async() => {
+        const tx = await testAccess.grantAccess(user, { from: owner });
+        assert.equal(
+            tx.logs[0].event,
+            'GrantedAccess',
+        );
+    });
+
+    describe('with authorized users', async() => {
+        beforeEach(async() => {
+            await testAccess.grantAccess(user, { from: owner });
+        });
+
+        it('authorized access is allowed', async() => {
+            const err = 'Error';
+            assert(await testAccess.testOnlyAuthorized(err, { from: user }));
+        });
+
+        it('addresses can be revoked access', async() => {
+            const tx = await testAccess.revokeAccess(user, { from: owner });
+            assert.equal(
+                tx.logs[0].event,
+                'RevokedAccess',
+            );
+        });
+    });
+});

--- a/test/access/Democracy.test.ts
+++ b/test/access/Democracy.test.ts
@@ -121,7 +121,7 @@ contract('Democracy', (accounts) => {
     /**
      * @test {Democracy#removeVoter}
      */
-    /* it('voters can be removed through a proposal.', async () => {
+    it('voters can be removed through a proposal.', async () => {
         const proposalData = web3.eth.abi.encodeFunctionCall({
             name: 'removeVoter',
             type: 'function',
@@ -139,12 +139,12 @@ contract('Democracy', (accounts) => {
         await voting.validate();
         await voting.enact();
         assert.isFalse(await democracy.isVoter(root));
-    }); */
+    });
 
     /**
      * @test {Democracy#addLeader}
      */
-    /* it('leaders can be added through a proposal.', async () => {
+    it('leaders can be added through a proposal.', async () => {
         const proposalData = web3.eth.abi.encodeFunctionCall({
             name: 'addLeader',
             type: 'function',
@@ -183,20 +183,20 @@ contract('Democracy', (accounts) => {
             await voting.validate();
             await voting.enact();
             await voting.cancel({ from: root });
-        }); */
+        });
 
         /**
          * @test {Democracy#renounceLeader}
          */
-        /* it('voters can renounce to their rights.', async () => {
+        it('voters can renounce to their rights.', async () => {
             await democracy.renounceLeader({ from: root });
             assert.isFalse(await democracy.isLeader(root));
-        }); */
+        });
 
         /**
          * @test {Democracy#removeLeader}
          */
-        /* it('leaders can be removed through a proposal.', async () => {
+        it('leaders can be removed through a proposal.', async () => {
             const proposalData = web3.eth.abi.encodeFunctionCall({
                 name: 'removeLeader',
                 type: 'function',
@@ -215,5 +215,5 @@ contract('Democracy', (accounts) => {
             await voting.enact();
             assert.isFalse(await democracy.isLeader(root));
         });
-    }); */
+    });
 });


### PR DESCRIPTION
I found useful to create a simpler version of `Administered.sol`.

There is one `owner` and a group of `authorized` users. There are functions to `grantAccess` and `revokeAccess` for users that only the `owner` can execute. Ownership can't be transferred.

There are `onlyAuthorized`  and `onlyOwner` modifiers.